### PR TITLE
Added circle background wrapper

### DIFF
--- a/lib/components/circles_background.dart
+++ b/lib/components/circles_background.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class CirclesBackground extends StatelessWidget {
+  final Widget child;
+
+  const CirclesBackground({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        // Two circles in the topleft of screen
+        Positioned(
+          top: -30,
+          left: -118,
+          child: Container(
+            width: 221,
+            height: 221,
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              color: Color.fromARGB(112, 194, 225, 252),
+            ),
+          ),
+        ),
+        Positioned(
+          top: -109,
+          left: -54,
+          child: Container(
+            width: 221,
+            height: 221,
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              color: Color.fromARGB(112, 194, 225, 252),
+            ),
+          ),
+        ),
+
+        // Actual page widget goes here
+        Scaffold(
+          backgroundColor: Colors.transparent,
+          body: child,
+        )
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'pages/login_page.dart';
 
 void main() {
   runApp(const MainApp());
@@ -10,7 +11,7 @@ class MainApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      home: Scaffold(),
+      home: LoginPage(),
     );
   }
 }

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -1,0 +1,16 @@
+import 'package:enjoyce/components/circles_background.dart';
+import 'package:flutter/material.dart';
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Colors.white,
+      body: CirclesBackground(
+        child: Center(child: Text("hello world")),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Wrap page widgets with `CirclesBackground` to layer the background behind

Sample Usage:
```
Scaffold(
  backgroundColor: Colors.white,
  body: CirclesBackground(
    child: Center(child: Text("hello world")),
  ),
);
```