### PR TITLE
Add Navigation Routes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:enjoyce/pages/start_page.dart';
 import 'pages/login_page.dart';
 
-void main() { //it runs the app (MainApp)
+void main() {
+  //it runs the app (MainApp)
   runApp(const MainApp());
 }
 
@@ -10,11 +11,13 @@ class MainApp extends StatelessWidget {
   const MainApp({super.key});
 
   @override
-  Widget build(BuildContext context){
-      return const MaterialApp(
-        title: 'Enjoyce Travel and Tours',
-        home: StartPage(),
-      );
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Enjoyce Travel and Tours',
+      home: const StartPage(),
+      routes: {
+        '/loginpage': (context) =>  const LoginPage(),
+      },
+    );
   }
 }
-

--- a/lib/pages/start_page.dart
+++ b/lib/pages/start_page.dart
@@ -10,9 +10,7 @@ class StartPage extends StatelessWidget {
     // Simulating some loading time before navigating to the login page
     Future.delayed(Duration(seconds: 2), () {
       // Navigating to the LoginPage after 2 seconds
-      Navigator.of(context).pushReplacement(MaterialPageRoute(
-        builder: (_) => LoginPage(), // Replace StartPage with LoginPage
-      ));
+      Navigator.pushReplacementNamed(context, "/loginpage");
     });
 
     return Scaffold(


### PR DESCRIPTION
Instead of calling `Navigator.pushReplacement` or other methods and passing in a builder method inside, we can just use **routes** in our `MaterialApp` to simplify navigation.

For more info, watch [this](https://www.youtube.com/watch?v=C6nTXjQFVKI).

(No change in functionality, this is purely for DX)